### PR TITLE
Make vcf path dynamic

### DIFF
--- a/genome-server.py
+++ b/genome-server.py
@@ -138,7 +138,7 @@ wallet = Wallet()
 payment = Payment(app, wallet)
 
 # path to the bulk VCF files to sell
-vcf_path = '/home/twenty-server/genome-server/vcffile'
+vcf_path = os.path.dirname(os.path.realpath(__file__)) + '/vcffile'
 
 
 # simple content model: dictionary of files w/ prices


### PR DESCRIPTION
The vcf path was previously hardcoded to match that of the initial creators. When users create a local copy of the folder, this path can vary. The change provides for an understanding of this and provides the user with a dynamic path to the vcf file.
